### PR TITLE
string formatting compatibility with python 2.6

### DIFF
--- a/azure_storage/storage.py
+++ b/azure_storage/storage.py
@@ -74,11 +74,13 @@ class AzureStorage(Storage):
             if self.cdn_host:
                 base_url = self.cdn_host
             
-            self._container_url = base_url.format({
+            container_detail = {
                 'protocol': self._get_protocol(),
                 'host': self._get_service()._get_host(),
                 'container': self.container,
-            })
+                }
+
+            self._container_url = base_url.format(**container_detail)
 
         return self._container_url
 


### PR DESCRIPTION
string formatting from dict doesn't work without using pointer notation in python 2.6
